### PR TITLE
Update revokests_key.py

### DIFF
--- a/aws_ir_plugins/revokests_key.py
+++ b/aws_ir_plugins/revokests_key.py
@@ -30,7 +30,7 @@ class Plugin(object):
         if self.dry_run is not True:
             self.client = self._get_client()
             username = self._get_username_for_key()
-            policy_document = self.__generate_inline_policy()
+            policy_document = self._generate_inline_policy()
             self._attach_inline_policy(username, policy_document)
             pass
 


### PR DESCRIPTION
Solves a problem with 

2017-07-24T15:21:24 - aws_ir.plans.key - INFO - Attempting key disable.
Traceback (most recent call last):
  File "/Users/akrug/workspace/incidents/env/bin/aws_ir", line 10, in <module>
    c.run()
  File "/Users/akrug/workspace/incidents/env/lib/python3.6/site-packages/aws_ir/cli.py", line 245, in run
    kc.mitigate()
  File "/Users/akrug/workspace/incidents/env/lib/python3.6/site-packages/aws_ir/plans/key.py", line 62, in mitigate
    dry_run=False
  File "/Users/akrug/workspace/incidents/env/lib/python3.6/site-packages/aws_ir_plugins/revokests_key.py", line 25, in __init__
    self.setup()
  File "/Users/akrug/workspace/incidents/env/lib/python3.6/site-packages/aws_ir_plugins/revokests_key.py", line 33, in setup
    policy_document = self.__generate_inline_policy()
AttributeError: 'Plugin' object has no attribute '_Plugin__generate_inline_policy'